### PR TITLE
Add few methods to result object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Methods:
 - `value!` – unwraps a result object, returns the value for success result, and throws an error for failure result
 - `value_or(other_value, &block)` – returns a value for success result or `other_value` for failure result (either calls `block` in case it given)
 - `or(&block)` - calls block for failure result, for success result does nothing
-- `or(success_proc, failure_proc)` - for success result calls success_proc with result value in args, for failure result calls failure_proc with error in args.
+- `either(success_proc, failure_proc)` - for success result calls success_proc with result value in args, for failure result calls failure_proc with error in args.
 
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Methods:
 - `failure?` – returns `true` for failure result and `false` for success result
 - `value!` – unwraps a result object, returns the value for success result, and throws an error for failure result
 - `value_or(other_value, &block)` – returns a value for success result or `other_value` for failure result (either calls `block` in case it given)
+- `or(&block)` - calls block for failure result, for success result does nothing
+- `or(success_proc, failure_proc)` - for success result calls success_proc with result value in args, for failure result calls failure_proc with error in args.
 
 
 ### Configuration

--- a/lib/resol/result.rb
+++ b/lib/resol/result.rb
@@ -10,6 +10,16 @@ module Resol
     # @!method value!
 
     def initialize(*); end
+
+    def or
+      return if success?
+
+      yield(@value)
+    end
+
+    def either(success_proc, failure_proc)
+      success? ? success_proc.call(@value) : failure_proc.call(@value)
+    end
   end
 
   class Success < Result

--- a/lib/resol/result.rb
+++ b/lib/resol/result.rb
@@ -12,9 +12,7 @@ module Resol
     def initialize(*); end
 
     def or
-      return if success?
-
-      yield(@value)
+      yield(@value) if failure?
     end
 
     def either(success_proc, failure_proc)

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Resol::Result do
     it { expect(result.failure?).to be_falsey }
     it { expect(result.value_or(:other_value)).to eq(:success_value) }
     it { expect(result.value!).to eq(:success_value) }
+    it { expect { result.or { raise "Some Error" } }.not_to raise_error }
+
+    it do
+      success_proc = instance_double(Proc)
+      failure_proc = instance_double(Proc)
+      allow(success_proc).to receive(:call).and_return("result")
+
+      expect(result.either(success_proc, failure_proc)).to eq("result")
+    end
   end
 
   describe Resol::Failure do
@@ -16,9 +25,18 @@ RSpec.describe Resol::Result do
     it { expect(result.success?).to be_falsey }
     it { expect(result.failure?).to be_truthy }
     it { expect(result.value_or(:other_value)).to eq(:other_value) }
+    it { expect { result.or { raise "Some Error" } }.to raise_error("Some Error") }
 
     it do
       expect { result.value! }.to raise_error(Resol::UnwrapError, "Failure result :failure_value")
+    end
+
+    it do
+      success_proc = instance_double(Proc)
+      failure_proc = instance_double(Proc)
+      allow(failure_proc).to receive(:call).and_return("result")
+
+      expect(result.either(success_proc, failure_proc)).to eq("result")
     end
   end
 end


### PR DESCRIPTION
# Changes

- Add `Resol::Result#or(&block)` for handling error cases.
- Add `Resol::Result#either(success_proc, failure_proc)` for easy handling both cases.

# Examples

## or

We don't want to return value on success, but we want to handle error:

```ruby
class Service
  def call
    run_command!
    success!
  end

  private

  def run_command!
    command = SomeCommand.call
    command.or { |error| handle_error!(error) }
  end
end
```

This method is needed to write more readable code.

## either

If you want to handle both cases without terminating:

```ruby
class Service
  def call
    run_command!
    success!
  end

  private

  def run_command!
    command = SomeCommand.call
    command.either(
      -> (result) { handle_result!(result) },
      -> (error) { p error.code },
    )
  end
end
```

without method:

```ruby
class Service
  def call
    run_command!
    success!
  end

  private

  def run_command!
    command = SomeCommand.call
    result = command.value_or { |error| handle_error!(error); return }
    handle_result!(result)
  end
end