### PR TITLE
Use Kernel#throw as success interrupter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resol (0.5.1)
+    resol (0.6.0)
       smart_initializer (~> 0.7)
 
 GEM
@@ -131,4 +131,4 @@ DEPENDENCIES
   simplecov-lcov
 
 BUNDLED WITH
-   2.2.19
+   2.2.21

--- a/lib/resol/version.rb
+++ b/lib/resol/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resol
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/spec/interruptions_spec.rb
+++ b/spec/interruptions_spec.rb
@@ -1,28 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe Resol::Service::Interruption do
-  describe Resol::Service::Success do
-    let(:object) { Resol::Service::Success.new(:some_data) }
+RSpec.describe Resol::Service::Failure do
+  let(:object) { Resol::Service::Failure.new(:some_data, data) }
 
-    it { expect(object.inspect).to eq("Resol::Service::Success: :some_data") }
+  context "without data" do
+    let(:data) { nil }
+
+    it { expect(object.inspect).to eq("Resol::Service::Failure: :some_data") }
     it { expect(object.message).to eq(":some_data") }
   end
 
-  describe Resol::Service::Failure do
-    let(:object) { Resol::Service::Failure.new(:some_data, data) }
+  context "with data" do
+    let(:data) { :data }
 
-    context "without data" do
-      let(:data) { nil }
-
-      it { expect(object.inspect).to eq("Resol::Service::Failure: :some_data") }
-      it { expect(object.message).to eq(":some_data") }
-    end
-
-    context "with data" do
-      let(:data) { :data }
-
-      it { expect(object.inspect).to eq("Resol::Service::Failure: :some_data => :data") }
-      it { expect(object.message).to eq(":some_data => :data") }
-    end
+    it { expect(object.inspect).to eq("Resol::Service::Failure: :some_data => :data") }
+    it { expect(object.message).to eq(":some_data => :data") }
   end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -70,6 +70,12 @@ class ServiceWithFailInTransaction < Resol::Service
   end
 end
 
+class HackyService < Resol::Service
+  def call
+    SuccessService.build.call
+  end
+end
+
 RSpec.describe Resol::Service do
   it "returns a success result" do
     expect(SuccessService.call!).to eq(:success_result)
@@ -111,6 +117,14 @@ RSpec.describe Resol::Service do
       end
 
       expect(DB.rollbacked).to eq(true)
+    end
+  end
+
+  context "when using instance #call inside other service" do
+    let(:expected_message) { "uncaught throw SuccessService" }
+
+    it "raises an exception" do
+      expect { HackyService.call! }.to raise_error(UncaughtThrowError, expected_message)
     end
   end
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -60,7 +60,7 @@ end
 
 class ServiceWithTransaction < Resol::Service
   def call
-    DB.transaction { success!(:value) }
+    DB.transaction { success! }
   end
 end
 
@@ -98,7 +98,7 @@ RSpec.describe Resol::Service do
   it "doesn't rollback transaction" do
     result = ServiceWithTransaction.call
     expect(result.success?).to eq(true)
-    expect(result.value!).to eq(:value)
+    expect(result.value!).to eq(nil)
     expect(DB.rollbacked).to eq(false)
   end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -31,7 +31,9 @@ class FailureService < Resol::Service
 end
 
 class EmptyService < Resol::Service
-  def call; end
+  def call
+    "some_string"
+  end
 end
 
 class ServiceWithCallbacks < Resol::Service
@@ -71,8 +73,11 @@ class ServiceWithFailInTransaction < Resol::Service
 end
 
 class HackyService < Resol::Service
+  param :count
+
   def call
-    SuccessService.build.call
+    success! unless count.zero?
+    HackyService.build(count + 1).call
   end
 end
 
@@ -121,10 +126,10 @@ RSpec.describe Resol::Service do
   end
 
   context "when using instance #call inside other service" do
-    let(:expected_message) { "uncaught throw SuccessService" }
+    let(:expected_message) { /uncaught throw #<HackyService/ }
 
     it "raises an exception" do
-      expect { HackyService.call! }.to raise_error(UncaughtThrowError, expected_message)
+      expect { HackyService.call!(0) }.to raise_error(UncaughtThrowError, expected_message)
     end
   end
 end


### PR DESCRIPTION
# Changes

- Use `Kernel#throw` and `Kernel#catch` instead of raising error on success.

## Before Change

We can't call `#success!` inside transaction block, because this will lead to a rollback.

```ruby
class Test < Resol::Service
  def call
    DB.transaction { success! } #= Led to a rollback
  end
end
```

## After Change

Now we can safely call success inside `transaction` block:

```ruby
class Test < Resol::Service
  def call
    DB.transaction { success! } #= COMMIT!
  end
end
```