### PR TITLE
Add error method to result object for retrieving error object

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,16 @@ Methods:
 - `failure?` – returns `true` for failure result and `false` for success result
 - `value!` – unwraps a result object, returns the value for success result, and throws an error for failure result
 - `value_or(other_value, &block)` – returns a value for success result or `other_value` for failure result (either calls `block` in case it given)
-- `or(&block)` - calls block for failure result, for success result does nothing
-- `either(success_proc, failure_proc)` - for success result calls success_proc with result value in args, for failure result calls failure_proc with error in args.
+- `error` – returns `nil` for success result and error object (with code and data) for failure result
+- `or(&block)` – calls block for failure result, for success result does nothing
+- `either(success_proc, failure_proc)` – for success result calls success_proc with result value in args, for failure result calls failure_proc with error in args.
 
+### Error object
+
+In case of failure you can get an error object with error code
+and data from `fail!` arguments. This can be done by method `error` on
+the result object and the returned object will have corresponding
+methods `code` and `data`.
 
 ### Configuration
 

--- a/lib/resol/result.rb
+++ b/lib/resol/result.rb
@@ -41,6 +41,10 @@ module Resol
     def value!
       @value
     end
+
+    def error
+      nil
+    end
   end
 
   class Failure < Result
@@ -67,6 +71,10 @@ module Resol
 
     def value!
       raise UnwrapError, "Failure result #{@value.inspect}"
+    end
+
+    def error
+      @value
     end
   end
 

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Resol::Result do
     it { expect(result.failure?).to be_falsey }
     it { expect(result.value_or(:other_value)).to eq(:success_value) }
     it { expect(result.value!).to eq(:success_value) }
+    it { expect(result.error).to be_nil }
     it { expect { result.or { raise "Some Error" } }.not_to raise_error }
 
     it do
@@ -25,6 +26,7 @@ RSpec.describe Resol::Result do
     it { expect(result.success?).to be_falsey }
     it { expect(result.failure?).to be_truthy }
     it { expect(result.value_or(:other_value)).to eq(:other_value) }
+    it { expect(result.error).to eq(:failure_value) }
     it { expect { result.or { raise "Some Error" } }.to raise_error("Some Error") }
 
     it do


### PR DESCRIPTION
Запилил метод error на Result, возвращает nil для Success, инстанс Service::Failure — для Failure.